### PR TITLE
Initiator should equal owner

### DIFF
--- a/surf_trashbin/lib/SurfHelper.php
+++ b/surf_trashbin/lib/SurfHelper.php
@@ -49,7 +49,7 @@ class SurfHelper {
         };
 
         // TODO add share type
-        $query = 'SELECT * FROM `*PREFIX*share` WHERE `share_with`=? AND `uid_owner`=?';
+        $query = 'SELECT * FROM `*PREFIX*share` WHERE `share_with`=? AND `uid_owner`=? AND `uid_initiator`=`uid_owner';
         $parameters = [$uid, $fuid];
 
         $statement = $this->dbConnection->prepare($query);


### PR DESCRIPTION
To make sure only the first person receiving a share from the functional is made a group owner, and other group members are not, we can add this extra check.